### PR TITLE
Fixed IntEnum error when formatting as int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+ - Fix crash in flake8 plugin on Python 3.11
+
 ## [0.1.3] - 2023-03-13
 
 ### Added

--- a/oida/flake8.py
+++ b/oida/flake8.py
@@ -32,4 +32,4 @@ class Plugin:
             )
             checker.visit(self._tree)
             for line, col, code, message in checker.violations:
-                yield line, col, f"ODA{code:03d} {message}", type(self)
+                yield line, col, f"ODA{code.value:03d} {message}", type(self)


### PR DESCRIPTION
When linting Oida for the first time, I encountered the following error:
```
poetry run flake8 oida
...
run_ast_checks
    for (line_number, offset, text, _) in runner:
  File "/Users/donwillems/Development/oida/oida/flake8.py", line 35, in run
    yield line, col, f"ODA{code:03d} {message}", type(self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.11/3.11.1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/enum.py", line 1225, in __format__
    return str.__format__(str(self), format_spec)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Unknown format code 'd' for object of type 'str'
```

This is caused by formatting `code` as an int, while the type is an Enum (it is defined as `class Code(int, enum.Enum)`, i.e. an `IntEnum`). To get the int value of the `code`, we need `code.value`.

After changing this line, the flake8 linter runs without errors.