### PR TITLE
Set `LIBCST_PARSER_TYPE` environment variable to `native`

### DIFF
--- a/oida/console.py
+++ b/oida/console.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -45,6 +46,9 @@ def main() -> None:
     componentize_parser.add_argument("new_path", type=Path, help="Path to move app to")
 
     args = parser.parse_args()
+
+    # Needed to parse Python 3.10 documents
+    os.environ.setdefault("LIBCST_PARSER_TYPE", "native")
 
     if args.command == "lint":
         if not run_linter(*args.paths, checks=args.checks):


### PR DESCRIPTION
Fixes issue https://github.com/kolonialno/oida/issues/9.

Setting `LIBCST_PARSER_TYPE` to `native` is needed to parse Python 3.10 syntax ([source](https://github.com/Instagram/LibCST/releases/tag/v0.4.0)). Not exactly sure where it's most appropriate to set this environment variable, but it looks like `libcst` is in use in both the `componentize` and `config` methods, so I figured it would be beneficial to set it at the top-level method. If you have other suggestions, please let me know.