### PR TITLE
Explicitly naming existing implicit Celery names

### DIFF
--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -3,7 +3,6 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
-from typing import Optional, Union
 
 import libcst as cst
 from libcst import BaseStatement, Decorator, FlattenSentinel, RemovalSentinel

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -217,8 +217,8 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
         if self.context.full_module_name is not None:
             current_module_name_list = self.context.full_module_name.split(".")
             new_module_name_list = self.new_module.split(".")
-            # The full module name is in the form: product_availability.core.services.data.supply
-            # while the module we are changing is of the form: tienda.product_availability.core
+            # The full module name is in the form: component.app.subdir.subdir.module
+            # while the module we are changing is of the form: project.component.app
             # We, therefore, need to check if the last two (string) components of the name of the
             # new module are equal to the first two (string) components of the name of the module
             # currently being processed. If we do not do this test - all tasks in the project
@@ -247,25 +247,6 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
                 cst.Arg(
                     keyword=cst.Name("name"),
                     value=cst.SimpleString(value=task_name),
-                    # Equal and comma are not strictly necessary - the code would be functional without these.
-                    # They are needed however to comply with coding conventions and pass the unit test.
-                    equal=cst.AssignEqual(
-                        whitespace_before=cst.SimpleWhitespace(value=""),
-                        whitespace_after=cst.SimpleWhitespace(value=""),
-                    ),
-                    comma=cst.Comma(
-                        whitespace_before=cst.SimpleWhitespace(value=""),
-                        whitespace_after=cst.ParenthesizedWhitespace(
-                            first_line=cst.TrailingWhitespace(
-                                whitespace=cst.SimpleWhitespace(value=""),
-                                comment=None,
-                                newline=cst.Newline(value=None),
-                            ),
-                            empty_lines=[],
-                            indent=True,
-                            last_line=cst.SimpleWhitespace(value="    "),
-                        ),
-                    ),
                 ),
             ) + arguments
             new_call = call.with_changes(args=arguments)

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import Optional
 
 import libcst as cst
 from libcst import matchers as m
@@ -51,6 +52,9 @@ def componentize_app(old_path: Path, new_path: Path) -> None:
 
     print("Updating app config")
     update_or_create_app_config(old_path, new_path)
+
+    print("Updating celery task naming")
+    update_celery_task_names(root_module, old_path, new_path)
 
     if shutil.which("isort"):
         print("Running isort")
@@ -185,3 +189,31 @@ def update_or_create_app_config(old_path: Path, new_path: Path) -> None:
             AppConfigUpdater(class_name, new_module, default_app_label)
         )
         apps_py_path.write_text(run_black(updated_module.code))
+
+
+class CeleryTaskNameUpdater(cst.CSTTransformer):
+    """
+    
+    """
+
+    def __init__(self, old_module: str, new_module: str) -> None:
+        print("Creating updater")
+        self.old_module = old_module
+        self.new_module = new_module
+
+    def visit_FunctionDef(self, node: cst.FunctionDef) -> Optional[bool]:
+        print(f"Visiting node: {node.name}")
+        print(f"    Decorators: {node.decorators}")
+        return True
+
+    def leave_FunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.CSTNode:
+        print(f"Leaving original node: {original_node.name}")
+        print(f"Leaving updated node: {updated_node.name}")
+        return updated_node
+
+
+def update_celery_task_names(root_module: Path, old_path: Path, new_path: Path) -> None:
+    print("Changing Celery task naming")
+    pass

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -208,7 +208,10 @@ class CeleryTaskNameUpdater(cst.CSTTransformer):
 
     def visit_Decorator(self, node: cst.Decorator) -> Optional[bool]:
         # Determine if the decorator is the @app.task decorator
-        if m.matches(node, m.Decorator(m.Call(m.Attribute(value=m.Name("app"), attr=m.Name("task"))))):
+        if m.matches(
+            node,
+            m.Decorator(m.Call(m.Attribute(value=m.Name("app"), attr=m.Name("task")))),
+        ):
             self.in_app += 1
         return super().visit_Decorator(node)
 
@@ -216,35 +219,78 @@ class CeleryTaskNameUpdater(cst.CSTTransformer):
         self, original_node: cst.Decorator, updated_node: cst.Decorator
     ) -> cst.CSTNode:
         # Determine if the decorator is the @app.task decorator
-        if m.matches(original_node, m.Decorator(m.Call(m.Attribute(value=m.Name("app"), attr=m.Name("task"))))):
+        if m.matches(
+            original_node,
+            m.Decorator(m.Call(m.Attribute(value=m.Name("app"), attr=m.Name("task")))),
+        ):
             self.in_app -= 1
         return updated_node
-    
+
     def leave_Call(
         self, original_node: cst.Call, updated_node: cst.Call
     ) -> cst.CSTNode:
         # self.in_app > 0 if we are in an @app.task decorator
         if self.in_app > 0:
             # Test if the name of the task is not explicitly set
-            if not m.matches(original_node, m.Call(args=[m.ZeroOrMore(), m.Arg(keyword=m.Name("name")), m.ZeroOrMore()])):
+            if not m.matches(
+                original_node,
+                m.Call(
+                    args=[m.ZeroOrMore(), m.Arg(keyword=m.Name("name")), m.ZeroOrMore()]
+                ),
+            ):
                 arguments = original_node.args
                 # The implicit name of the task is the path to the old module concatenated with the function name.
-                task_name =  self.old_module + "." + self.function_name
-                arguments = (cst.Arg(keyword=cst.Name("name"), value=task_name),) + arguments
+                task_name = '"' + self.old_module + "." + self.function_name + '"'
+                arguments = (
+                    cst.Arg(
+                        keyword=cst.Name("name"),
+                        value=cst.SimpleString(value=task_name),
+                        equal=cst.AssignEqual(
+                            whitespace_before=cst.SimpleWhitespace(value=""),
+                            whitespace_after=cst.SimpleWhitespace(value=""),
+                        ),
+                        comma=cst.Comma(
+                            whitespace_before=cst.SimpleWhitespace(value=""),
+                            whitespace_after=cst.ParenthesizedWhitespace(
+                                first_line=cst.TrailingWhitespace(
+                                    whitespace=cst.SimpleWhitespace(value=""),
+                                    comment=None,
+                                    newline=cst.Newline(value=None),
+                                ),
+                                empty_lines=[],
+                                indent=True,
+                                last_line=cst.SimpleWhitespace(value="    ")
+                            )
+                        )
+                    ),
+                ) + arguments
                 new_node = updated_node.with_changes(args=arguments)
                 return new_node
         return updated_node
-    
+
     def visit_FunctionDef(self, node: cst.FunctionDef) -> Optional[bool]:
-        if m.matches(node, m.FunctionDef(decorators=[m.ZeroOrMore(), m.Decorator(m.Call(m.Attribute(value=m.Name("app"), attr=m.Name("task")))), m.ZeroOrMore()])):
+        if m.matches(
+            node,
+            m.FunctionDef(
+                decorators=[
+                    m.ZeroOrMore(),
+                    m.Decorator(
+                        m.Call(m.Attribute(value=m.Name("app"), attr=m.Name("task")))
+                    ),
+                    m.ZeroOrMore(),
+                ]
+            ),
+        ):
             # We need the name of the function to recreate the implicit task name.
             self.function_name = node.name.value
         return super().visit_FunctionDef(node)
-    
-    def leave_FunctionDef(self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef) -> cst.CSTNode:
+
+    def leave_FunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.CSTNode:
         self.function_name = None
         return updated_node
-    
+
 
 def update_celery_task_names(root_module: Path, old_path: Path, new_path: Path) -> None:
     print("Changing Celery task naming")

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -213,23 +213,6 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
         self.old_module = old_module
         self.new_module = new_module
 
-    def transform_module_impl(self, tree: cst.Module) -> cst.Module:
-        if self.context.full_module_name is not None:
-            current_module_name_list = self.context.full_module_name.split(".")
-            new_module_name_list = self.new_module.split(".")
-            # The full module name is in the form: component.app.subdir.subdir.module
-            # while the module we are changing is of the form: project.component.app
-            # We, therefore, need to check if the last two (string) components of the name of the
-            # new module are equal to the first two (string) components of the name of the module
-            # currently being processed. If we do not do this test - all tasks in the project
-            # (e.g. tienda) will be prepended with the component name, which is wrong.
-            if (
-                len(current_module_name_list) >= 2
-                and len(new_module_name_list) >= 2
-                and current_module_name_list[:2] == new_module_name_list[-2:]
-            ):
-                return tree.visit(self)
-        return tree
 
     def update_decorator(
         self, decorator: cst.Decorator, task_name: str

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -5,7 +5,7 @@ import textwrap
 from pathlib import Path
 
 import libcst as cst
-from libcst import BaseStatement, Decorator, FlattenSentinel, RemovalSentinel
+from libcst import BaseStatement, FlattenSentinel, RemovalSentinel
 from libcst import matchers as m
 from libcst.codemod import (
     CodemodContext,
@@ -244,7 +244,7 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
             ),
         ):
             call = decorator.decorator
-            if isinstance(call, cst.Call): 
+            if isinstance(call, cst.Call):
                 arguments = call.args
                 arguments = (  # type: ignore
                     cst.Arg(

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -233,7 +233,7 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
                 return tree.visit(self)
         return tree
 
-    def visit_Decorator(self, node: cst.Decorator) -> Optional[bool]:
+    def visit_Decorator(self, node: cst.Decorator) -> bool | None:
         # Determine if the decorator is the @app.task decorator
         if m.matches(
             node,

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -261,7 +261,7 @@ def update_celery_task_names(root_module: Path, old_path: Path, new_path: Path) 
     old_module = get_module(old_path)
     new_module = get_module(new_path)
 
-    files = [str(path) for path in root_module.rglob("*.py")]
+    files = [str(path) for path in new_path.rglob("*.py")]
     context = CodemodContext()
     codemod = CeleryTaskNameUpdater(context, old_module, new_module)
 

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from typing import Optional, Union
 
 import libcst as cst
-from libcst import BaseStatement, Decorator, FlattenSentinel, RemovalSentinel, matchers as m
+from libcst import BaseStatement, Decorator, FlattenSentinel, RemovalSentinel
+from libcst import matchers as m
 from libcst.codemod import CodemodContext, parallel_exec_transform_with_prettyprint
 from libcst.codemod.commands.rename import RenameCommand as BaseRenameCommand
 from libcst.metadata import QualifiedNameProvider
@@ -241,8 +242,8 @@ class CeleryTaskNameUpdater(cst.CSTTransformer):
                 arguments = original_node.args
                 # The implicit name of the task is the path to the old module concatenated with the function name.
                 task_name = f'"{self.old_module}.{self.function_name}"'
-               
-                arguments = (   # type: ignore
+
+                arguments = (  # type: ignore
                     cst.Arg(
                         keyword=cst.Name("name"),
                         value=cst.SimpleString(value=task_name),

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -206,12 +206,9 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
     It also checks whether the name has already been explicitly set, if so the name is NOT changed.
     """
 
-    def __init__(
-        self, context: CodemodContext, module_name: str
-    ) -> None:
+    def __init__(self, context: CodemodContext, module_name: str) -> None:
         super().__init__(context=context)
         self.module_name = module_name
-
 
     def update_decorator(
         self, decorator: cst.Decorator, task_name: str

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -244,7 +244,7 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
 
     def leave_Decorator(
         self, original_node: cst.Decorator, updated_node: cst.Decorator
-    ) -> Union[Decorator, FlattenSentinel[Decorator], RemovalSentinel]:
+    ) -> Decorator | FlattenSentinel[Decorator] | RemovalSentinel:
         # Determine if the decorator is the @app.task decorator
         if m.matches(
             original_node,

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -8,7 +8,11 @@ from typing import Optional, Union
 import libcst as cst
 from libcst import BaseStatement, Decorator, FlattenSentinel, RemovalSentinel
 from libcst import matchers as m
-from libcst.codemod import CodemodContext, ContextAwareTransformer, parallel_exec_transform_with_prettyprint
+from libcst.codemod import (
+    CodemodContext,
+    ContextAwareTransformer,
+    parallel_exec_transform_with_prettyprint,
+)
 from libcst.codemod.commands.rename import RenameCommand as BaseRenameCommand
 from libcst.metadata import QualifiedNameProvider
 
@@ -203,7 +207,9 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
     It also checks whether the name has already been explicitly set, if so the name is NOT changed.
     """
 
-    def __init__(self, context: CodemodContext, old_module: str, new_module: str) -> None:
+    def __init__(
+        self, context: CodemodContext, old_module: str, new_module: str
+    ) -> None:
         super().__init__(context=context)
         self.old_module = old_module
         self.new_module = new_module

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -207,7 +207,7 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
     """
 
     def __init__(
-        self, context: CodemodContext, old_module: str, new_module: str
+        self, context: CodemodContext, module_name: str
     ) -> None:
         super().__init__(context=context)
         self.old_module = old_module

--- a/tests/test_command_componentize.py
+++ b/tests/test_command_componentize.py
@@ -77,7 +77,7 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
                 topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
             ) -> None:
                 pass
-               
+            
             @app.some.other.decorator(
                 foo="bar",
             )
@@ -106,7 +106,7 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
                 topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
             ) -> None:
                 pass
-                
+            
             @app.some.other.decorator(
                 foo="bar",
             )
@@ -130,13 +130,9 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
 def testapp_celery_task_name_updater(module: str, expected_output: str) -> None:
     source_tree = cst.parse_module(textwrap.dedent(module))
     transformer = CeleryTaskNameUpdater(
-            old_module="project.app.tasks",
-            new_module="project.component.app.tasks",
-        )
+        old_module="project.app.tasks",
+        new_module="project.component.app.tasks",
+    )
     updated_module = source_tree.visit(transformer)
     expected_module = cst.parse_module(textwrap.dedent(expected_output))
-    print("\n\n----------------------------------------- EXPECTED")
-    print(f"{expected_module}")
-    print("----------------------------------------- UPDATED")
-    print(f"{updated_module}")
     assert updated_module.deep_equals(expected_module)

--- a/tests/test_command_componentize.py
+++ b/tests/test_command_componentize.py
@@ -4,7 +4,9 @@ import libcst as cst
 import pytest
 
 from oida.commands.componentize import AppConfigUpdater, CeleryTaskNameUpdater
-
+from libcst.codemod import (
+    CodemodContext,
+)
 
 @pytest.mark.parametrize(
     "module,expected_output",
@@ -129,7 +131,9 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
 )
 def testapp_celery_task_name_updater(module: str, expected_output: str) -> None:
     source_tree = cst.parse_module(textwrap.dedent(module))
+    context = CodemodContext()
     transformer = CeleryTaskNameUpdater(
+        context=context,
         old_module="project.app.tasks",
         new_module="project.component.app.tasks",
     )

--- a/tests/test_command_componentize.py
+++ b/tests/test_command_componentize.py
@@ -134,8 +134,7 @@ def testapp_celery_task_name_updater(module: str, expected_output: str) -> None:
     context = CodemodContext()
     transformer = CeleryTaskNameUpdater(
         context=context,
-        old_module="project.app.tasks",
-        new_module="project.component.app.tasks",
+        module_name="project.app.tasks",
     )
     updated_module_code = run_black(source_tree.visit(transformer).code)
     expected_module_code = run_black(

--- a/tests/test_command_componentize.py
+++ b/tests/test_command_componentize.py
@@ -5,6 +5,7 @@ import pytest
 from libcst.codemod import CodemodContext
 
 from oida.commands.componentize import AppConfigUpdater, CeleryTaskNameUpdater
+from oida.utils import run_black
 
 
 @pytest.mark.parametrize(
@@ -136,6 +137,6 @@ def testapp_celery_task_name_updater(module: str, expected_output: str) -> None:
         old_module="project.app.tasks",
         new_module="project.component.app.tasks",
     )
-    updated_module = source_tree.visit(transformer)
-    expected_module = cst.parse_module(textwrap.dedent(expected_output))
-    assert updated_module.deep_equals(expected_module)
+    updated_module_code = run_black(source_tree.visit(transformer).code)
+    expected_module_code = run_black(cst.parse_module(textwrap.dedent(expected_output)).code)
+    assert updated_module_code == expected_module_code

--- a/tests/test_command_componentize.py
+++ b/tests/test_command_componentize.py
@@ -77,7 +77,7 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
                 topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
             ) -> None:
                 pass
-            
+
             @app.some.other.decorator(
                 foo="bar",
             )
@@ -106,7 +106,7 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
                 topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
             ) -> None:
                 pass
-            
+
             @app.some.other.decorator(
                 foo="bar",
             )

--- a/tests/test_command_componentize.py
+++ b/tests/test_command_componentize.py
@@ -2,11 +2,10 @@ import textwrap
 
 import libcst as cst
 import pytest
+from libcst.codemod import CodemodContext
 
 from oida.commands.componentize import AppConfigUpdater, CeleryTaskNameUpdater
-from libcst.codemod import (
-    CodemodContext,
-)
+
 
 @pytest.mark.parametrize(
     "module,expected_output",

--- a/tests/test_command_componentize.py
+++ b/tests/test_command_componentize.py
@@ -80,7 +80,7 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
                
             @app.some.other.decorator(
                 foo="bar",
-            ) 
+            )
             @app.task(
                 name="other_dir.some_other_function",
                 max_retries=10,
@@ -135,4 +135,8 @@ def testapp_celery_task_name_updater(module: str, expected_output: str) -> None:
         )
     updated_module = source_tree.visit(transformer)
     expected_module = cst.parse_module(textwrap.dedent(expected_output))
+    print("\n\n----------------------------------------- EXPECTED")
+    print(f"{expected_module}")
+    print("----------------------------------------- UPDATED")
+    print(f"{updated_module}")
     assert updated_module.deep_equals(expected_module)

--- a/tests/test_command_componentize.py
+++ b/tests/test_command_componentize.py
@@ -138,5 +138,7 @@ def testapp_celery_task_name_updater(module: str, expected_output: str) -> None:
         new_module="project.component.app.tasks",
     )
     updated_module_code = run_black(source_tree.visit(transformer).code)
-    expected_module_code = run_black(cst.parse_module(textwrap.dedent(expected_output)).code)
+    expected_module_code = run_black(
+        cst.parse_module(textwrap.dedent(expected_output)).code
+    )
     assert updated_module_code == expected_module_code

--- a/tests/test_command_componentize.py
+++ b/tests/test_command_componentize.py
@@ -3,7 +3,7 @@ import textwrap
 import libcst as cst
 import pytest
 
-from oida.commands.componentize import AppConfigUpdater
+from oida.commands.componentize import AppConfigUpdater, CeleryTaskNameUpdater
 
 
 @pytest.mark.parametrize(
@@ -53,6 +53,52 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
             class_name="FooAppConfig",
             module="project.component.app",
             default_app_label="app",
+        )
+    )
+
+    expected_module = cst.parse_module(textwrap.dedent(expected_output))
+    assert updated_module.deep_equals(expected_module)
+
+
+@pytest.mark.parametrize(
+    "module,expected_output",
+    [
+        (
+            """\
+            @app.task(
+                max_retries=10,
+                default_retry_delay=60,
+                queue=settings.TASK_QUEUE_LOW_LATENCY_TRACKING,
+            )
+            def publish_tracking_data_to_pubsub(
+                topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
+            ) -> None:
+                pass
+            """,
+            """\
+            @app.task(
+                name="project.app.tasks.publish_tracking_data_to_pubsub",
+                max_retries=10,
+                default_retry_delay=60,
+                queue=settings.TASK_QUEUE_LOW_LATENCY_TRACKING,
+            )
+            def publish_tracking_data_to_pubsub(
+                topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
+            ) -> None:
+                pass
+            """,
+        ),
+    ],
+    ids=[
+        "add label, update class name and name",
+    ],
+)
+def testapp_celery_task_name_updater(module: str, expected_output: str) -> None:
+    wrapper = cst.MetadataWrapper(cst.parse_module(textwrap.dedent(module)))
+    updated_module = wrapper.visit(
+        CeleryTaskNameUpdater(
+            old_module="project.app.tasks",
+            new_module="project.component.app.tasks",
         )
     )
 


### PR DESCRIPTION
When componentizing code celery tasks need to retain their old name to not break during a rolling deploy.
At the moment the name is set implicitly. The name follows the folder structure. Problem is that the folder structure changes when componentizing. The implicit name would then also change.
To retain the same name for a task we need to set the name of the task explicitly by adding a `name` attribute to the `@app.task` decorator.

Closes: CORE-231