### PR TITLE
Add option to exclude path from violations

### DIFF
--- a/oida/commands/config.py
+++ b/oida/commands/config.py
@@ -6,12 +6,12 @@ from ..config_generator import collect_violations, update_component_config
 from ..utils import run_black
 
 
-def generate_config(project_root: Path) -> None:
+def generate_config(project_root: Path, excluded_path: Path | None = None) -> None:
     """
     Auto-generate config files for the given component.
     """
 
-    all_volations = collect_violations(project_root)
+    all_volations = collect_violations(project_root, excluded_path)
 
     for component_path, violations in all_volations.items():
         config_path = component_path / "confcomponent.py"

--- a/oida/commands/config.py
+++ b/oida/commands/config.py
@@ -11,9 +11,9 @@ def generate_config(project_root: Path, excluded_path: Path | None = None) -> No
     Auto-generate config files for the given component.
     """
 
-    all_volations = collect_violations(project_root, excluded_path)
+    all_violations = collect_violations(project_root, excluded_path)
 
-    for component_path, violations in all_volations.items():
+    for component_path, violations in all_violations.items():
         config_path = component_path / "confcomponent.py"
         if not config_path.exists():
             if not violations:

--- a/oida/config_generator.py
+++ b/oida/config_generator.py
@@ -65,7 +65,7 @@ def collect_violations_in_file(path: Path) -> set[str]:
 
 def update_component_config(node: cst.Module, allowed_imports: set[str]) -> cst.Module:
     """
-    Update a compontent config. Returns a modified copy of the provided cst.
+    Update a component config. Returns a modified copy of the provided cst.
     """
 
     new_body: list[cst.SimpleStatementLine | cst.BaseCompoundStatement] = []

--- a/oida/config_generator.py
+++ b/oida/config_generator.py
@@ -37,14 +37,14 @@ def collect_violations_in_dir(
 
     violations: set[str] = set()
     for child in path.iterdir():
+        # Skip collecting violations if match with the excluded path
+        if excluded_path and child.match(excluded_path.as_posix()):
+            continue
+
         if child.is_dir():
-            if excluded_path and excluded_path.name == child.name:
-                continue
             if (child / "__init__.py").exists():
                 violations |= collect_violations_in_dir(child, excluded_path)
         elif child.suffix == ".py":
-            if excluded_path and child.parent.name == excluded_path.name:
-                continue
             violations |= collect_violations_in_file(child)
 
     return violations

--- a/oida/console.py
+++ b/oida/console.py
@@ -37,6 +37,9 @@ def main() -> None:
     config_parser.add_argument(
         "project_root", type=Path, help="Path to project root directory"
     )
+    config_parser.add_argument(
+        "excluded_path", type=Path, help="Path to be excluded from violations"
+    )
 
     componentize_parser = subparsers.add_parser(
         "componentize",
@@ -54,7 +57,7 @@ def main() -> None:
         if not run_linter(*args.paths, checks=args.checks):
             sys.exit(1)
     elif args.command == "config":
-        generate_config(args.project_root)
+        generate_config(args.project_root, args.excluded_path)
     elif args.command == "componentize":
         componentize_app(args.old_path, args.new_path)
     else:

--- a/tests/test_ignore_generator.py
+++ b/tests/test_ignore_generator.py
@@ -74,6 +74,35 @@ def test_collect_violations(project_path: Path) -> None:
     }
 
 
+@pytest.mark.project_files(
+    {
+        "project/other/__init__.py": "",
+        "project/other/app/__init__.py": "",
+        "project/other/app/services.py": """
+            from project.component.app.services import private
+            private()
+        """,
+        "project/other/app/tests/__init__.py": "",
+        "project/other/app/tests/test_methods.py": """
+            from project.component.app.tests.utils import create_util
+            create_util()
+        """,
+    }
+)
+def test_collect_violations_excluded_path(project_path: Path) -> None:
+    violations = collect_violations(project_path / "project", Path("tests"))
+    assert violations == {
+        (project_path / "project" / "component"): {
+            "project.other.app.services.private",
+            "project.other.app.services.also_private",
+            "project.other.app.selectors.private",
+        },
+        (project_path / "project" / "other"): {
+            "project.component.app.services.private",
+        },
+    }
+
+
 @pytest.mark.parametrize(
     "current,violations,expected",
     [

--- a/tests/test_ignore_generator.py
+++ b/tests/test_ignore_generator.py
@@ -61,7 +61,6 @@ def test_override_file_with_marker(project_path: Path) -> None:
 )
 def test_collect_violations(project_path: Path) -> None:
     violations = collect_violations(project_path / "project")
-    print(violations)
     assert violations == {
         (project_path / "project" / "component"): {
             "project.other.app.services.private",

--- a/tests/test_ignore_generator.py
+++ b/tests/test_ignore_generator.py
@@ -89,6 +89,7 @@ def test_collect_violations(project_path: Path) -> None:
     }
 )
 def test_collect_violations_excluded_path(project_path: Path) -> None:
+    # Excluded path is a single folder
     violations = collect_violations(project_path / "project", Path("tests"))
     assert violations == {
         (project_path / "project" / "component"): {
@@ -98,6 +99,33 @@ def test_collect_violations_excluded_path(project_path: Path) -> None:
         },
         (project_path / "project" / "other"): {
             "project.component.app.services.private",
+        },
+    }
+
+    # Excluded path contains multiple folders
+    violations = collect_violations(project_path / "project", Path("other/app/tests"))
+    assert violations == {
+        (project_path / "project" / "component"): {
+            "project.other.app.services.private",
+            "project.other.app.services.also_private",
+            "project.other.app.selectors.private",
+        },
+        (project_path / "project" / "other"): {
+            "project.component.app.services.private",
+        },
+    }
+
+    # Excluded path doesn't match, violation is listed
+    violations = collect_violations(project_path / "project", Path("other2/app/tests"))
+    assert violations == {
+        (project_path / "project" / "component"): {
+            "project.other.app.services.private",
+            "project.other.app.services.also_private",
+            "project.other.app.selectors.private",
+        },
+        (project_path / "project" / "other"): {
+            "project.component.app.services.private",
+            "project.component.app.tests.utils.create_util",
         },
     }
 


### PR DESCRIPTION
An attempt to solve https://github.com/kolonialno/oida/issues/10. Simple approach, but seems to work for the straight forward cases.

Currently I've just added an `excluded_path` argument to the `config` method, but I'm wondering if we should allow to exclude multiple paths when creating the violations list. WDYT?