### PR TITLE
Bump version to 0.1.3 - Celery explicit names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 
 [Unreleased]: https://github.com/kolonialno/oida/compare/v0.1.3...HEAD
-[0.1.3]: https://github.com/kolonialno/oida/compare/v0.1.1...v0.1.3
+[0.1.3]: https://github.com/kolonialno/oida/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/kolonialno/oida/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/kolonialno/oida/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/kolonialno/oida/compare/v0.1.0-rc.1-rc.1...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2023-03-13
+
+### Added
+- The `componentize` command now adds explicit names for Celery tasks.
+
 ## [0.1.2] - 2023-02-09
 
 ### Changed
@@ -28,7 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/kolonialno/oida/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/kolonialno/oida/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/kolonialno/oida/compare/v0.1.1...v0.1.3
 [0.1.2]: https://github.com/kolonialno/oida/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/kolonialno/oida/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/kolonialno/oida/compare/v0.1.0-rc.1-rc.1...v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oida"
-version = "0.1.2"
+version = "0.1.3"
 description = "Oida is Oda's linter that enforces code style and modularization in our Django projects."
 authors = ["Oda <tech@oda.com>"]
 license = "MIT"


### PR DESCRIPTION
Bump Oida version to 0.1.3. Including Celery explicite naming.