### PR TITLE
Fixed support for task types inheriting from celery app.task

### DIFF
--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -239,14 +239,17 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
     def leave_FunctionDef(
         self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
     ) -> BaseStatement | FlattenSentinel[BaseStatement] | RemovalSentinel:
-        celery_task_decorator = m.Decorator(
+        celery_app_task_decorator = m.Decorator(
             m.Call(m.Attribute(value=m.Name("app"), attr=m.Name("task")))
+        )
+        celery_coalesced_task_decorator = m.Decorator(
+            m.Call(m.Attribute(value=m.Name("coalesced_task")))
         )
         # The implicit name of the task is the path to the old module concatenated with the function name.
         task_name = f'"{self.module_name}.{original_node.name.value}"'
         decorators = [
             self.update_decorator(decorator=decorator, task_name=task_name)
-            if m.matches(decorator, celery_task_decorator)
+            if m.matches(decorator, celery_app_task_decorator | celery_coalesced_task_decorator)
             else decorator
             for decorator in updated_node.decorators
         ]

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -239,12 +239,14 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
     def leave_FunctionDef(
         self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
     ) -> BaseStatement | FlattenSentinel[BaseStatement] | RemovalSentinel:
+
+        # Matching tasks defined with @app.task
         celery_app_task_decorator = m.Decorator(
             m.Call(m.Attribute(value=m.Name("app"), attr=m.Name("task")))
         )
-        celery_coalesced_task_decorator = m.Decorator(
-            m.Call(m.Attribute(value=m.Name("coalesced_task")))
-        )
+        # Matching tasks defined with @coalesced_task
+        celery_coalesced_task_decorator = m.Decorator(m.Call(m.Name("coalesced_task")))
+
         # The implicit name of the task is the path to the old module concatenated with the function name.
         task_name = f'"{self.module_name}.{original_node.name.value}"'
         decorators = [

--- a/oida/commands/componentize.py
+++ b/oida/commands/componentize.py
@@ -249,7 +249,9 @@ class CeleryTaskNameUpdater(ContextAwareTransformer):
         task_name = f'"{self.module_name}.{original_node.name.value}"'
         decorators = [
             self.update_decorator(decorator=decorator, task_name=task_name)
-            if m.matches(decorator, celery_app_task_decorator | celery_coalesced_task_decorator)
+            if m.matches(
+                decorator, celery_app_task_decorator | celery_coalesced_task_decorator
+            )
             else decorator
             for decorator in updated_node.decorators
         ]

--- a/tests/test_command_componentize.py
+++ b/tests/test_command_componentize.py
@@ -93,6 +93,19 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
                 topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
             ) -> None:
                 pass
+                
+            @coalesced_task(
+                max_retries=10,
+                default_retry_delay=60,
+                queue=settings.TASK_QUEUE_LOW_LATENCY_TRACKING,
+            )
+            @app.some.other.decorator(
+                foo="bar",
+            )
+            def some_third_function(
+                topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
+            ) -> None:
+                pass
             """,
             """\
             @app.task(
@@ -119,6 +132,20 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
                 queue=settings.TASK_QUEUE_LOW_LATENCY_TRACKING,
             )
             def some_other_function(
+                topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
+            ) -> None:
+                pass
+                
+            @coalesced_task(
+                name="project.app.tasks.some_third_function",
+                max_retries=10,
+                default_retry_delay=60,
+                queue=settings.TASK_QUEUE_LOW_LATENCY_TRACKING,
+            )
+            @app.some.other.decorator(
+                foo="bar",
+            )
+            def some_third_function(
                 topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
             ) -> None:
                 pass

--- a/tests/test_command_componentize.py
+++ b/tests/test_command_componentize.py
@@ -93,7 +93,7 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
                 topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
             ) -> None:
                 pass
-                
+
             @coalesced_task(
                 max_retries=10,
                 default_retry_delay=60,
@@ -135,7 +135,7 @@ def testapp_config_updater(module: str, expected_output: str) -> None:
                 topic: str, msg: bytes | dict, attributes: dict[str, str] | None = None
             ) -> None:
                 pass
-                
+
             @coalesced_task(
                 name="project.app.tasks.some_third_function",
                 max_retries=10,


### PR DESCRIPTION
This solution add the `coalesced_task` type to the componentization command so that explicit names are also added for these type of tasks.
A better solution would be to test for inheritance from celery tasks to also add explicit names for other (unknown or new) task types. But that is for later.

Closes: CORE-330