### PR TITLE
Fix crash related to ignored modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+ - Fix crash when using ignored\_modules project config option
+
 ## [0.1.5] - 2023-04-20
 
 ### Fixed

--- a/oida/config.py
+++ b/oida/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass, field
+from itertools import zip_longest
 from typing import Iterable
 
 if sys.version_info >= (3, 11):
@@ -25,8 +26,8 @@ class ProjectConfig:
 
         for ignore in self.ignored_modules:
             if all(
-                name == "*" or len(path) < i or name == path[i]
-                for i, name in enumerate(ignore.split("."))
+                ignore_part == "*" or path_part == ignore_part or ignore_part is None
+                for path_part, ignore_part in zip_longest(path, ignore.split("."))
             ):
                 return True
 

--- a/tests/test_isolation_non_violations.py
+++ b/tests/test_isolation_non_violations.py
@@ -250,3 +250,23 @@ def test_ignored_paths_wildcard(
     checker: ComponentIsolationChecker, violations: list[Violation]
 ) -> None:
     assert not violations
+
+
+@pytest.mark.pyproject_toml(
+    """\
+    [tool.oida]
+    ignored_modules = ['project.*.tests']
+    """
+)
+@pytest.mark.module(
+    """\
+    from project.other.app.services import service
+    service()
+    """,
+    module="project.app.tests",
+    name="test_foobar",
+)
+def test_ignored_paths_submodule(
+    checker: ComponentIsolationChecker, violations: list[Violation]
+) -> None:
+    assert not violations

--- a/tests/test_isolation_violations.py
+++ b/tests/test_isolation_violations.py
@@ -207,3 +207,32 @@ def test_isolation_unused_import_violation(
         )
     ]
     assert checker.referenced_imports == {"project.other.app.selectors.select"}
+
+
+@pytest.mark.pyproject_toml(
+    """\
+    [tool.oida]
+    ignored_modules = ['project.*.tests']
+    """
+)
+@pytest.mark.module(
+    """\
+    from project.other.app.services import service
+    service()
+    """,
+    module="project",
+    name="test_foobar",
+)
+def test_ignored_paths_shorter_path_than_ignore(
+    checker: ComponentIsolationChecker, violations: list[Violation]
+) -> None:
+    """Test that ignores at a deeper path are not used"""
+    assert violations == [
+        Violation(
+            line=2,
+            column=0,
+            code=Code.ODA005,
+            message='Private attribute "project.other.app.services.service" referenced',
+        )
+    ]
+    assert checker.referenced_imports == {"project.other.app.services.service"}


### PR DESCRIPTION
When checking a module at a path higher in the hierarchy than one that was ignored we ended up with an index error. Fix taken from #5