### PR TITLE
Skip private/protected functions in keyword-only checker

### DIFF
--- a/oida/checkers/services.py
+++ b/oida/checkers/services.py
@@ -127,6 +127,9 @@ class KeywordOnlyChecker(Checker):
         # Skip dunder methods (e.g., __init__, __str__, __repr__)
         if self._is_dunder_method(node.name):
             return
+        # Skip private/protected functions (leading underscore)
+        if node.name.startswith("_"):
+            return
 
         args = node.args
 

--- a/tests/test_keyword_only_checker.py
+++ b/tests/test_keyword_only_checker.py
@@ -272,6 +272,31 @@ def test_dunder_methods_not_checked(
     assert not violations
 
 
+@pytest.mark.module(
+    """\
+def _private(username, email):
+    pass
+"""
+)
+def test_private_function_not_checked(
+    checker: KeywordOnlyChecker, violations: list[Violation]
+) -> None:
+    assert not violations
+
+
+@pytest.mark.module(
+    """\
+class UserService:
+    def _private_method(self, username, email):
+        pass
+"""
+)
+def test_private_method_not_checked(
+    checker: KeywordOnlyChecker, violations: list[Violation]
+) -> None:
+    assert not violations
+
+
 # Tests for file/directory detection
 
 


### PR DESCRIPTION
This [PR](https://github.com/kolonialno/alma/pull/21587) in alma... I _could_ add `#noida`for each of the functions... But, I think this rule is overreaching without this exception.