### PR TITLE
Add keyword_only_ignore_private configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,14 @@ These are the checks currently implemented in Oida:
 modules use keyword-only parameters (with the `*` separator). This applies to files
 named `services.py` or `selectors.py`, or files within `services/` or `selectors/`
 directories. Inner functions and methods of nested classes are excluded from this check.
+
+## Configuration
+
+Oida can be configured through `pyproject.toml` under the `[tool.oida]` section:
+
+```toml
+[tool.oida]
+keyword_only_ignore_private = true
+```
+
+ * **keyword_only_ignore_private:** When set to `true`, private functions (prefixed with `_`) are excluded from the keyword-only parameter check (ODA007). Defaults to `false`.

--- a/oida/checkers/services.py
+++ b/oida/checkers/services.py
@@ -129,9 +129,8 @@ class KeywordOnlyChecker(Checker):
             return
 
         # Optionally skip private functions (prefixed with _ but not dunder)
-        if (
-            self.project_config.keyword_only_ignore_private
-            and node.name.startswith("_")
+        if self.project_config.keyword_only_ignore_private and node.name.startswith(
+            "_"
         ):
             return
 

--- a/oida/checkers/services.py
+++ b/oida/checkers/services.py
@@ -128,7 +128,8 @@ class KeywordOnlyChecker(Checker):
         if self._is_dunder_method(node.name):
             return
 
-        # Optionally skip private functions (prefixed with _ but not dunder)
+        # Optionally skip private functions (prefixed with _, dunder methods handled
+        # above)
         if self.project_config.keyword_only_ignore_private and node.name.startswith(
             "_"
         ):

--- a/oida/checkers/services.py
+++ b/oida/checkers/services.py
@@ -128,6 +128,13 @@ class KeywordOnlyChecker(Checker):
         if self._is_dunder_method(node.name):
             return
 
+        # Optionally skip private functions (prefixed with _ but not dunder)
+        if (
+            self.project_config.keyword_only_ignore_private
+            and node.name.startswith("_")
+        ):
+            return
+
         args = node.args
 
         # Determine if this is an instance/class method by checking the first parameter

--- a/oida/config.py
+++ b/oida/config.py
@@ -16,6 +16,7 @@ else:
 class ProjectConfig:
     ignored_modules: list[str] = field(default_factory=list)
     allowed_imports: list[str] = field(default_factory=list)
+    keyword_only_ignore_private: bool = False
 
     @classmethod
     def from_pyproject_toml(cls, pyproject_toml: str) -> ProjectConfig:

--- a/tests/test_keyword_only_checker.py
+++ b/tests/test_keyword_only_checker.py
@@ -505,3 +505,112 @@ def test_test_dirs_not_checked(
     checker: KeywordOnlyChecker, violations: list[Violation]
 ) -> None:
     assert not violations
+
+
+# Tests for keyword_only_ignore_private configuration
+
+
+@pytest.mark.module(
+    """\
+def _private_function(username, email):
+    pass
+"""
+)
+def test_private_function_checked_by_default(
+    checker: KeywordOnlyChecker, violations: list[Violation]
+) -> None:
+    assert violations == [
+        Violation(
+            line=1,
+            column=0,
+            code=Code.ODA007,
+            message="Service and selector functions must use keyword-only parameters (add * before parameters)",
+        )
+    ]
+
+
+@pytest.mark.pyproject_toml(
+    """\
+    [tool.oida]
+    keyword_only_ignore_private = true
+    """
+)
+@pytest.mark.module(
+    """\
+def _private_function(username, email):
+    pass
+"""
+)
+def test_private_function_ignored_when_configured(
+    checker: KeywordOnlyChecker, violations: list[Violation]
+) -> None:
+    assert not violations
+
+
+@pytest.mark.pyproject_toml(
+    """\
+    [tool.oida]
+    keyword_only_ignore_private = true
+    """
+)
+@pytest.mark.module(
+    """\
+def public_function(username, email):
+    pass
+"""
+)
+def test_public_function_still_checked_when_private_ignored(
+    checker: KeywordOnlyChecker, violations: list[Violation]
+) -> None:
+    assert violations == [
+        Violation(
+            line=1,
+            column=0,
+            code=Code.ODA007,
+            message="Service and selector functions must use keyword-only parameters (add * before parameters)",
+        )
+    ]
+
+
+@pytest.mark.pyproject_toml(
+    """\
+    [tool.oida]
+    keyword_only_ignore_private = true
+    """
+)
+@pytest.mark.module(
+    """\
+class UserService:
+    def _private_method(self, username, email):
+        pass
+"""
+)
+def test_private_method_ignored_when_configured(
+    checker: KeywordOnlyChecker, violations: list[Violation]
+) -> None:
+    assert not violations
+
+
+@pytest.mark.pyproject_toml(
+    """\
+    [tool.oida]
+    keyword_only_ignore_private = false
+    """
+)
+@pytest.mark.module(
+    """\
+def _private_function(username, email):
+    pass
+"""
+)
+def test_private_function_checked_when_config_false(
+    checker: KeywordOnlyChecker, violations: list[Violation]
+) -> None:
+    assert violations == [
+        Violation(
+            line=1,
+            column=0,
+            code=Code.ODA007,
+            message="Service and selector functions must use keyword-only parameters (add * before parameters)",
+        )
+    ]

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -15,3 +15,16 @@ def test_project_config_from_mark(project_config: ProjectConfig) -> None:
 
 def test_project_config_no_mark(project_config: ProjectConfig) -> None:
     assert project_config.ignored_modules == []
+    assert project_config.keyword_only_ignore_private is False
+
+
+@pytest.mark.pyproject_toml(
+    """\
+    [tool.oida]
+    keyword_only_ignore_private = true
+    """
+)
+def test_project_config_keyword_only_ignore_private(
+    project_config: ProjectConfig,
+) -> None:
+    assert project_config.keyword_only_ignore_private is True


### PR DESCRIPTION
## Summary
This PR adds a new configuration option `keyword_only_ignore_private` to allow users to exclude private functions and methods (those prefixed with `_`) from the keyword-only parameter check (ODA007).

## Key Changes
- **Configuration**: Added `keyword_only_ignore_private` boolean field to `ProjectConfig` class with a default value of `False`
- **Checker Logic**: Updated `KeywordOnlyChecker._check_function()` to skip private functions when the configuration option is enabled
- **Documentation**: Added configuration section to README.md explaining the new option
- **Tests**: Added comprehensive test coverage including:
  - Private functions checked by default
  - Private functions ignored when configured
  - Public functions still checked when private functions are ignored
  - Private methods ignored when configured
  - Explicit false configuration still checks private functions

## Implementation Details
- The check specifically targets functions/methods starting with `_` (but excludes dunder methods which are already skipped)
- The configuration is read from `pyproject.toml` under `[tool.oida]` section
- Defaults to `false` to maintain backward compatibility and existing behavior
- Works for both standalone functions and class methods

https://claude.ai/code/session_01VBusSyBThf162jT5wrKF8j