### PR TITLE
Add error code to CLI error output

### DIFF
--- a/oida/commands/linter.py
+++ b/oida/commands/linter.py
@@ -7,7 +7,7 @@ from ..discovery import find_modules, get_component_config, get_project_config
 def print_violation(
     file: Path, line: int, column: int, code: Code, message: str
 ) -> None:
-    print(f"{file}:{line}:{column}: {message}")
+    print(f"{file}:{line}:{column}: ODA{code.value:03d} {message}")
 
 
 def run_linter(*paths: Path, checks: list[str]) -> bool:


### PR DESCRIPTION
So that it is easier to figure out which rule was triggered. The flake8 plugin already has this